### PR TITLE
FIX Replace new FieldsValidator with SimpleFieldsValidator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,15 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    with:
+      extra_jobs: |
+        - php: 8.0
+          phpunit: false
+          endtoend: true
+          endtoend_suite: admin
+          endtoend_config: vendor/silverstripe/admin/behat.yml
+        - php: 8.1
+          phpunit: false
+          endtoend: true
+          endtoend_suite: cms
+          endtoend_config: vendor/silverstripe/cms/behat.yml

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -10,3 +10,8 @@ Signify\ComposableValidators\Validators\SimpleFieldsValidator:
 SilverStripe\Admin\LeftAndMain:
   extra_requirements_css:
     - 'guysartorelli/silverstripe-composable-validators:client/dist/left-and-main.css'
+
+# Replace new FieldsValidator with our SimpleFieldsValidator
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Forms\FieldsValidator:
+    class: Signify\ComposableValidators\Validators\SimpleFieldsValidator

--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,12 @@
   },
   "require": {
     "php": "^7.3 || ^8.0",
-    "silverstripe/framework": "^4.10.0",
+    "silverstripe/framework": "^4.13.18",
     "signify-nz/silverstripe-searchfilter-arraylist": "^1.0.0"
   },
   "require-dev": {
     "silverstripe/cms": "^4.0",
+    "silverstripe/frameworktest": "^0.4.13",
     "silverstripe/asset-admin": "^1.6",
     "dnadesign/silverstripe-elemental": "^4.0",
     "phpunit/phpunit": "^9.5",

--- a/src/Validators/SimpleFieldsValidator.php
+++ b/src/Validators/SimpleFieldsValidator.php
@@ -2,7 +2,7 @@
 
 namespace Signify\ComposableValidators\Validators;
 
-use SilverStripe\Forms\Validator;
+use SilverStripe\Forms\FieldsValidator;
 
 /**
  * A validator to ensure that all form fields are internally valid.
@@ -13,7 +13,7 @@ use SilverStripe\Forms\Validator;
  * This class is to avoid the use of, say, RequiredFields::create([]), which
  * relies on an implementation detail to ensure that fields are validated.
  */
-class SimpleFieldsValidator extends Validator
+class SimpleFieldsValidator extends FieldsValidator
 {
     /**
      * Array of FormField subclasses that shouldn't be validated in AJAX validation calls.
@@ -29,7 +29,7 @@ class SimpleFieldsValidator extends Validator
      * @param array $data
      * @return bool
      */
-    public function php($data, bool $isAjax = false)
+    public function php($data, bool $isAjax = false): bool
     {
         $valid = true;
         $fields = $this->form->Fields();


### PR DESCRIPTION
This ensures anyone checking for a `FieldsValidator` will correctly fetch out the `SimpleFieldsValidator` which does the same job, and it ensures that there is only _one_ fields validator there, rather than having both the new default `FieldsValidator` _and_ our `SimpleFieldsValidator` which would duplicate effort.