### PR TITLE
MNT Conflict with silverstripe/framework 5.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,9 @@
     "dnadesign/silverstripe-elemental": "^5",
     "silverstripe/recipe-testing": "^3"
   },
+  "conflict": {
+    "silverstripe/framework": ">=5.1.0"
+  },
   "extra": {
     "expose": [
       "client/dist",


### PR DESCRIPTION
That version will require a new minor release of this module, which there's already a PR for, due to conflicts in the method signature of the new ArrayList::excludeAny() method and that method in the searchfilterable arraylist.

This is really just to make CI happy - in a real project the conflict won't be necessary since composer will just grab the most recent version anyway.