### PR TITLE
chore: fix permissions for CI yet again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
+      actions: write
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
     with:
       extra_jobs: |


### PR DESCRIPTION
As per https://github.com/silverstripe/gha-ci/pull/146 (don't merge until that's been merged)